### PR TITLE
Offset as limit

### DIFF
--- a/src/test/java/com/rbkmoney/magista/OffsetPerformanceTest.java
+++ b/src/test/java/com/rbkmoney/magista/OffsetPerformanceTest.java
@@ -7,8 +7,6 @@ import com.rbkmoney.geck.common.util.TypeUtil;
 import com.rbkmoney.magista.dao.InvoiceEventDao;
 import com.rbkmoney.magista.domain.tables.pojos.InvoiceEventStat;
 import com.rbkmoney.woody.thrift.impl.http.THSpawnClientBuilder;
-import io.github.benas.randombeans.EnhancedRandomBuilder;
-import io.github.benas.randombeans.api.EnhancedRandom;
 import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -93,7 +91,7 @@ public class OffsetPerformanceTest extends AbstractIntegrationTest {
             } catch (TException ex) {
                 throw new RuntimeException(ex);
             }
-        }, partyId, shopId, start.atStartOfDay(), end.atStartOfDay(),1000, 1000);
+        }, partyId, shopId, start.atStartOfDay(), end.atStartOfDay(), 1000, 1000);
     }
 
     private void doOffset(String category, Function<StatRequest, StatResponse> action, String partyId, String shopId, LocalDateTime fromTime, LocalDateTime toTime, int offsetStep, int size) throws TException {


### PR DESCRIPTION
В даном методе, мы полностью избегаем offset, делая подзапрос, где подставляем offset в limit:
```sql
select "mst"."invoice_event_stat"."party_id", "mst"."invoice_event_stat"."party_shop_id", "mst"."invoice_event_stat"."invoice_id", "mst"."invoice_event_stat"."invoice_created_at", "mst"."invoice_event_stat"."invoice_status", "mst"."invoice_event_stat"."invoice_status_details", "mst"."invoice_event_stat"."invoice_product", "mst"."invoice_event_stat"."invoice_description", "mst"."invoice_event_stat"."invoice_due", "mst"."invoice_event_stat"."invoice_amount", "mst"."invoice_event_stat"."invoice_currency_code", "mst"."invoice_event_stat"."invoice_cart", "mst"."invoice_event_stat"."invoice_context_type", "mst"."invoice_event_stat"."invoice_context" from "mst"."invoice_event_stat" where ("mst"."invoice_event_stat"."event_category" = 'INVOICE'::"mst"."invoice_event_category" and "mst"."invoice_event_stat"."party_id" = 'test' and "mst"."invoice_event_stat"."party_shop_id" = 'test' and "mst"."invoice_event_stat"."invoice_created_at" >= cast('2017-01-01T00:00' as timestamp) and "mst"."invoice_event_stat"."invoice_created_at" < cast('2018-01-01T00:00' as timestamp) and "mst"."invoice_event_stat"."id" < (select min(id) from (select "mst"."invoice_event_stat"."id" from "mst"."invoice_event_stat" where ("mst"."invoice_event_stat"."event_category" = 'INVOICE'::"mst"."invoice_event_category" and "mst"."invoice_event_stat"."party_id" = 'test' and "mst"."invoice_event_stat"."party_shop_id" = 'test' and "mst"."invoice_event_stat"."invoice_created_at" >= cast('2017-01-01T00:00' as timestamp) and "mst"."invoice_event_stat"."invoice_created_at" < cast('2018-01-01T00:00' as timestamp)) order by "mst"."invoice_event_stat"."invoice_created_at" desc limit 22000) as "alias_106017252")) order by "mst"."invoice_event_stat"."invoice_created_at" desc limit 1000;
```

**Результаты:**
Total count of invoices - 40139
Result of processing: invoices, 41 requests, time = 238774 ms, average = 5823.756097560976, min = 2203, max = 10064193, max = 1080
Total count of payments - 39861
Result of processing: payments, 40 requests, time = 226786 ms, average = 5669.65, min = 4010, max = 8977