### PR TITLE
Yet another query optimization

### DIFF
--- a/src/main/java/com/rbkmoney/magista/dao/impl/ReportDaoImpl.java
+++ b/src/main/java/com/rbkmoney/magista/dao/impl/ReportDaoImpl.java
@@ -11,6 +11,7 @@ import com.rbkmoney.magista.domain.enums.PayoutStatus;
 import com.rbkmoney.magista.domain.enums.RefundStatus;
 import com.rbkmoney.magista.exception.DaoException;
 import org.jooq.Field;
+import org.jooq.Name;
 import org.jooq.Operator;
 import org.jooq.Query;
 import org.jooq.impl.DSL;
@@ -277,8 +278,78 @@ public class ReportDaoImpl extends AbstractDao implements ReportDao {
             Optional<Long> fromId,
             int limit
     ) throws DaoException {
+        Name invoiceDataIdFieldName = DSL.name("_payment_data_id");
+        Name invoiceEventIdFieldName = DSL.name("_payment_event_id");
+
         Query query = getDslContext()
+                .withRecursive("t")
+                .as(getDslContext().select(
+                        PAYMENT_DATA.ID.as(invoiceDataIdFieldName),
+                        PAYMENT_EVENT.ID.as(invoiceEventIdFieldName)
+                        ).from(PAYMENT_DATA)
+                                .join(PAYMENT_EVENT)
+                                .on(
+                                        appendDateTimeRangeConditions(
+                                                appendConditions(
+                                                        PAYMENT_DATA.PARTY_ID.eq(UUID.fromString(partyId))
+                                                                .and(PAYMENT_DATA.PARTY_SHOP_ID.eq(shopId))
+                                                                .and(PAYMENT_DATA.INVOICE_ID.eq(PAYMENT_EVENT.INVOICE_ID))
+                                                                .and(PAYMENT_DATA.PAYMENT_ID.eq(PAYMENT_EVENT.PAYMENT_ID))
+                                                                .and(PAYMENT_EVENT.EVENT_TYPE.eq(InvoiceEventType.INVOICE_PAYMENT_STATUS_CHANGED))
+                                                                .and(PAYMENT_EVENT.PAYMENT_STATUS.eq(com.rbkmoney.magista.domain.enums.InvoicePaymentStatus.captured)),
+                                                        Operator.AND,
+                                                        new ConditionParameterSource()
+                                                                .addValue(PAYMENT_EVENT.ID, fromId.orElse(null), GREATER)
+                                                                .addValue(PAYMENT_DATA.INVOICE_ID, invoiceId.orElse(null), EQUALS)
+                                                                .addValue(PAYMENT_DATA.PAYMENT_ID, paymentId.orElse(null), EQUALS)
+                                                ),
+                                                PAYMENT_EVENT.EVENT_CREATED_AT,
+                                                fromTime,
+                                                toTime
+                                        )
+                                )
+                                .orderBy(PAYMENT_EVENT.ID)
+                                .limit(1)
+                                .unionAll(
+                                        getDslContext().select(
+                                                DSL.field(DSL.name("payment_data_id"), Long.class).as(invoiceDataIdFieldName),
+                                                DSL.field(DSL.name("payment_event_id"), Long.class).as(invoiceEventIdFieldName)
+                                        ).from("t")
+                                        .join(
+                                                DSL.lateral(
+                                        getDslContext().select(
+                                                PAYMENT_DATA.ID.as("payment_data_id"),
+                                                PAYMENT_EVENT.ID.as("payment_event_id")
+                                        ).from(PAYMENT_DATA)
+                                                .join(PAYMENT_EVENT)
+                                                .on(
+                                                        appendDateTimeRangeConditions(
+                                                                appendConditions(
+                                                                        PAYMENT_DATA.PARTY_ID.eq(UUID.fromString(partyId))
+                                                                                .and(PAYMENT_DATA.PARTY_SHOP_ID.eq(shopId))
+                                                                                .and(PAYMENT_DATA.INVOICE_ID.eq(PAYMENT_EVENT.INVOICE_ID))
+                                                                                .and(PAYMENT_DATA.PAYMENT_ID.eq(PAYMENT_EVENT.PAYMENT_ID))
+                                                                                .and(PAYMENT_EVENT.EVENT_TYPE.eq(InvoiceEventType.INVOICE_PAYMENT_STATUS_CHANGED))
+                                                                                .and(PAYMENT_EVENT.PAYMENT_STATUS.eq(com.rbkmoney.magista.domain.enums.InvoicePaymentStatus.captured))
+                                                                                .and(PAYMENT_EVENT.ID.gt(DSL.field(invoiceEventIdFieldName, Long.class))),
+                                                                        Operator.AND,
+                                                                        new ConditionParameterSource()
+                                                                                .addValue(PAYMENT_DATA.INVOICE_ID, invoiceId.orElse(null), EQUALS)
+                                                                                .addValue(PAYMENT_DATA.PAYMENT_ID, paymentId.orElse(null), EQUALS)
+                                                                ),
+                                                                PAYMENT_EVENT.EVENT_CREATED_AT,
+                                                                fromTime,
+                                                                toTime
+                                                        )
+                                                )
+                                                .orderBy(PAYMENT_EVENT.ID)
+                                                .limit(1)
+                                                )
+                                        ).on(true)
+                                )
+                )
                 .select(
+                        PAYMENT_EVENT.ID,
                         PAYMENT_DATA.INVOICE_ID,
                         PAYMENT_DATA.PAYMENT_ID,
                         PAYMENT_DATA.PARTY_ID,
@@ -311,7 +382,6 @@ public class ReportDaoImpl extends AbstractDao implements ReportDao {
                         PAYMENT_DATA.PAYMENT_PARTY_REVISION,
                         PAYMENT_DATA.PAYMENT_CONTEXT_TYPE,
                         PAYMENT_DATA.PAYMENT_CONTEXT,
-                        PAYMENT_EVENT.ID,
                         PAYMENT_EVENT.EVENT_ID,
                         PAYMENT_EVENT.EVENT_CREATED_AT,
                         PAYMENT_EVENT.EVENT_TYPE,
@@ -329,29 +399,11 @@ public class ReportDaoImpl extends AbstractDao implements ReportDao {
                         PAYMENT_EVENT.PAYMENT_PROVIDER_ID,
                         PAYMENT_EVENT.PAYMENT_TERMINAL_ID
                 )
-                .from(PAYMENT_DATA)
+                .from("t")
+                .join(PAYMENT_DATA)
+                .on(PAYMENT_DATA.ID.eq(DSL.field(invoiceDataIdFieldName, Long.class)))
                 .join(PAYMENT_EVENT)
-                .on(
-                        appendDateTimeRangeConditions(
-                                appendConditions(
-                                        PAYMENT_DATA.PARTY_ID.eq(UUID.fromString(partyId))
-                                                .and(PAYMENT_DATA.PARTY_SHOP_ID.eq(shopId))
-                                                .and(PAYMENT_DATA.INVOICE_ID.eq(PAYMENT_EVENT.INVOICE_ID))
-                                                .and(PAYMENT_DATA.PAYMENT_ID.eq(PAYMENT_EVENT.PAYMENT_ID))
-                                                .and(PAYMENT_EVENT.EVENT_TYPE.eq(InvoiceEventType.INVOICE_PAYMENT_STATUS_CHANGED))
-                                                .and(PAYMENT_EVENT.PAYMENT_STATUS.eq(com.rbkmoney.magista.domain.enums.InvoicePaymentStatus.captured)),
-                                        Operator.AND,
-                                        new ConditionParameterSource()
-                                                .addValue(PAYMENT_EVENT.ID, fromId.orElse(null), GREATER)
-                                                .addValue(PAYMENT_DATA.INVOICE_ID, invoiceId.orElse(null), EQUALS)
-                                                .addValue(PAYMENT_DATA.PAYMENT_ID, paymentId.orElse(null), EQUALS)
-                                ),
-                                PAYMENT_EVENT.EVENT_CREATED_AT,
-                                fromTime,
-                                toTime
-                        )
-                )
-                .orderBy(PAYMENT_EVENT.ID)
+                .on(PAYMENT_EVENT.ID.eq(DSL.field(invoiceEventIdFieldName, Long.class)))
                 .limit(limit);
 
         return fetch(query, statPaymentMapper);


### PR DESCRIPTION
```sql
WITH RECURSIVE t AS (
  (
    select payment_data.id as _payment_data_id, payment_event.id as _payment_event_id
    from mst.payment_data
           join mst.payment_event on ("mst"."payment_data"."party_id" = '24b0768d-fa41-427a-b034-8a8d6be8f397' and
                                      "mst"."payment_data"."party_shop_id" = '17227459-1560-4dcf-869f-333507aecb45' and
                                      "mst"."payment_data"."invoice_id" = mst.payment_event."invoice_id" and
                                      "mst"."payment_data"."payment_id" = payment_event."payment_id" and
                                      payment_event."event_type" = 'INVOICE_PAYMENT_STATUS_CHANGED' and
                                      payment_event."payment_status" = 'captured' and payment_event."id" > 38199019 and
                                      payment_event."event_created_at" >= timestamp '2018-11-30 21:00:00.0' and
                                      payment_event."event_created_at" < timestamp '2018-12-31 20:59:59.0')
    order by payment_event."id"
    limit 1
  )
  UNION ALL
  SELECT payment_data_id as _payment_data_id, payment_event_id as _payment_event_id
  from t,
       lateral (
         select payment_data.id as payment_data_id, payment_event.id as payment_event_id
         from mst.payment_data
                join mst.payment_event on ("mst"."payment_data"."party_id" = '24b0768d-fa41-427a-b034-8a8d6be8f397' and
                                           "mst"."payment_data"."party_shop_id" =
                                           '17227459-1560-4dcf-869f-333507aecb45' and
                                           "mst"."payment_data"."invoice_id" = mst.payment_event."invoice_id" and
                                           "mst"."payment_data"."payment_id" = payment_event."payment_id" and
                                           payment_event."event_type" = 'INVOICE_PAYMENT_STATUS_CHANGED' and
                                           payment_event."payment_status" = 'captured' and
                                           payment_event."id" > t._payment_event_id and
                                           payment_event."event_created_at" >= timestamp '2018-11-30 21:00:00.0' and
                                           payment_event."event_created_at" < timestamp '2018-12-31 20:59:59.0')
         order by payment_event."id"
         limit 1
         ) as kek
)
SELECT t._payment_event_id, payment_data.*, payment_event.*
FROM t
       join mst.payment_data on (payment_data.id = t._payment_data_id)
       join mst.payment_event on (payment_event.id = t._payment_event_id)
limit 1000;
```