### PR TITLE
Add cache for invoice getter method

### DIFF
--- a/src/main/java/com/rbkmoney/magista/service/InvoiceService.java
+++ b/src/main/java/com/rbkmoney/magista/service/InvoiceService.java
@@ -48,7 +48,7 @@ public class InvoiceService {
         List<InvoiceData> enrichedInvoiceEvents = invoiceEvents.stream()
                 .map(invoiceData -> {
                     if (invoiceData.getEventType() == INVOICE_STATUS_CHANGED) {
-                        InvoiceData previousInvoiceData = invoiceDao.get(invoiceData.getInvoiceId());
+                        InvoiceData previousInvoiceData = getInvoiceData(invoiceData.getInvoiceId());
                         BeanUtil.merge(previousInvoiceData, invoiceData);
                     }
                     return invoiceData;


### PR DESCRIPTION
Поменял **invoiceDao.get** на **getInvoiceData**, потому что там используются кэши, а был просто Dao метод.