### PR TITLE
Skip previous events from event sink

### DIFF
--- a/src/main/java/com/rbkmoney/magista/dao/impl/AdjustmentDaoImpl.java
+++ b/src/main/java/com/rbkmoney/magista/dao/impl/AdjustmentDaoImpl.java
@@ -55,9 +55,10 @@ public class AdjustmentDaoImpl extends AbstractDao implements AdjustmentDao {
                                         .onConflict(ADJUSTMENT_DATA.INVOICE_ID, ADJUSTMENT_DATA.PAYMENT_ID, ADJUSTMENT_DATA.ADJUSTMENT_ID)
                                         .doUpdate()
                                         .set(adjustmentDataRecord)
+                                        .where(ADJUSTMENT_DATA.EVENT_ID.le(adjustmentDataRecord.getEventId()))
                 )
                 .collect(Collectors.toList());
-        batchExecute(queries, 1);
+        batchExecute(queries);
     }
 
 }

--- a/src/main/java/com/rbkmoney/magista/dao/impl/InvoiceDaoImpl.java
+++ b/src/main/java/com/rbkmoney/magista/dao/impl/InvoiceDaoImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.rbkmoney.magista.domain.Tables.INVOICE_DATA;
+import static com.rbkmoney.magista.domain.Tables.PAYMENT_DATA;
 
 @Component
 public class InvoiceDaoImpl extends AbstractDao implements InvoiceDao {
@@ -71,7 +72,10 @@ public class InvoiceDaoImpl extends AbstractDao implements InvoiceDao {
                         invoiceDataRecord ->
                                 getDslContext().update(INVOICE_DATA)
                                         .set(invoiceDataRecord)
-                                        .where(INVOICE_DATA.INVOICE_ID.eq(invoiceDataRecord.getInvoiceId()))
+                                        .where(
+                                                INVOICE_DATA.INVOICE_ID.eq(invoiceDataRecord.getInvoiceId())
+                                                        .and(INVOICE_DATA.EVENT_ID.le(invoiceDataRecord.getEventId()))
+                                        )
                 )
                 .collect(Collectors.toList());
         batchExecute(queries);

--- a/src/main/java/com/rbkmoney/magista/dao/impl/PaymentDaoImpl.java
+++ b/src/main/java/com/rbkmoney/magista/dao/impl/PaymentDaoImpl.java
@@ -72,9 +72,8 @@ public class PaymentDaoImpl extends AbstractDao implements PaymentDao {
                                 .set(paymentDataRecord)
                                 .where(
                                         PAYMENT_DATA.INVOICE_ID.eq(paymentDataRecord.getInvoiceId())
-                                                .and(
-                                                        PAYMENT_DATA.PAYMENT_ID.eq(paymentDataRecord.getPaymentId())
-                                                )
+                                                .and(PAYMENT_DATA.PAYMENT_ID.eq(paymentDataRecord.getPaymentId()))
+                                                .and(PAYMENT_DATA.EVENT_ID.le(paymentDataRecord.getEventId()))
                                 )
                 )
                 .collect(Collectors.toList());

--- a/src/main/java/com/rbkmoney/magista/dao/impl/RefundDaoImpl.java
+++ b/src/main/java/com/rbkmoney/magista/dao/impl/RefundDaoImpl.java
@@ -54,8 +54,9 @@ public class RefundDaoImpl extends AbstractDao implements RefundDao {
                                         .onConflict(REFUND_DATA.INVOICE_ID, REFUND_DATA.PAYMENT_ID, REFUND_DATA.REFUND_ID)
                                         .doUpdate()
                                         .set(refundDataRecord)
+                                        .where(REFUND_DATA.EVENT_ID.le(refundDataRecord.getEventId()))
                 )
                 .collect(Collectors.toList());
-        batchExecute(queries, 1);
+        batchExecute(queries);
     }
 }

--- a/src/test/java/com/rbkmoney/magista/dao/AdjustmentDaoTest.java
+++ b/src/test/java/com/rbkmoney/magista/dao/AdjustmentDaoTest.java
@@ -2,6 +2,7 @@ package com.rbkmoney.magista.dao;
 
 import com.rbkmoney.magista.dao.impl.AdjustmentDaoImpl;
 import com.rbkmoney.magista.domain.tables.pojos.AdjustmentData;
+import com.rbkmoney.magista.domain.tables.pojos.RefundData;
 import com.rbkmoney.magista.exception.DaoException;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,20 @@ public class AdjustmentDaoTest extends AbstractDaoTest {
         adjustmentDao.save(List.of(adjustment));
 
         assertEquals(adjustment, adjustmentDao.get(adjustment.getInvoiceId(), adjustment.getPaymentId(), adjustment.getAdjustmentId()));
+    }
+
+    @Test
+    public void updatePreviousEventTest() {
+        AdjustmentData adjustmentData = random(AdjustmentData.class);
+
+        adjustmentDao.save(List.of(adjustmentData));
+        adjustmentDao.save(List.of(adjustmentData));
+
+        AdjustmentData adjustmentDataWithPreviousEventId = new AdjustmentData(adjustmentData);
+        adjustmentDataWithPreviousEventId.setEventId(adjustmentData.getEventId() - 1);
+
+        adjustmentDao.save(List.of(adjustmentDataWithPreviousEventId));
+        assertEquals(adjustmentData, adjustmentDao.get(adjustmentData.getInvoiceId(), adjustmentData.getPaymentId(), adjustmentData.getAdjustmentId()));
     }
 
 }

--- a/src/test/java/com/rbkmoney/magista/dao/InvoiceDaoTest.java
+++ b/src/test/java/com/rbkmoney/magista/dao/InvoiceDaoTest.java
@@ -34,6 +34,20 @@ public class InvoiceDaoTest extends AbstractDaoTest {
     }
 
     @Test
+    public void updatePreviousEventTest() {
+        InvoiceData invoiceData = random(InvoiceData.class);
+
+        invoiceDao.insert(List.of(invoiceData));
+        invoiceDao.update(List.of(invoiceData));
+
+        InvoiceData invoiceDataWithPreviousEventId = new InvoiceData(invoiceData);
+        invoiceDataWithPreviousEventId.setEventId(invoiceData.getEventId() - 1);
+
+        invoiceDao.update(List.of(invoiceDataWithPreviousEventId));
+        assertEquals(invoiceData, invoiceDao.get(invoiceData.getInvoiceId()));
+    }
+
+    @Test
     public void testBatchUpsert() {
         String invoiceId = "invoiceId";
 

--- a/src/test/java/com/rbkmoney/magista/dao/InvoiceDaoTest.java
+++ b/src/test/java/com/rbkmoney/magista/dao/InvoiceDaoTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,7 +58,9 @@ public class InvoiceDaoTest extends AbstractDaoTest {
                                     invoiceData.setInvoiceId(invoiceId);
                                     return invoiceData;
                                 }
-                        ).collect(Collectors.toList());
+                        )
+                .sorted(Comparator.comparing(InvoiceData::getEventId))
+                .collect(Collectors.toList());
 
         invoiceDao.insert(invoices);
         invoiceDao.insert(invoices);

--- a/src/test/java/com/rbkmoney/magista/dao/PaymentDaoTest.java
+++ b/src/test/java/com/rbkmoney/magista/dao/PaymentDaoTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -65,6 +66,7 @@ public class PaymentDaoTest extends AbstractDaoTest {
                                     return paymentData;
                                 }
                         )
+                .sorted(Comparator.comparing(PaymentData::getEventId))
         ).collect(Collectors.toList());
 
         paymentDao.insert(payments);

--- a/src/test/java/com/rbkmoney/magista/dao/PaymentDaoTest.java
+++ b/src/test/java/com/rbkmoney/magista/dao/PaymentDaoTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static io.github.benas.randombeans.api.EnhancedRandom.randomStreamOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 @ContextConfiguration(classes = {PaymentDaoImpl.class})
 public class PaymentDaoTest extends AbstractDaoTest {
@@ -32,6 +33,20 @@ public class PaymentDaoTest extends AbstractDaoTest {
         paymentDao.update(List.of(paymentData));
         paymentDao.update(List.of(paymentData));
 
+        assertEquals(paymentData, paymentDao.get(paymentData.getInvoiceId(), paymentData.getPaymentId()));
+    }
+
+    @Test
+    public void updatePreviousEventTest() {
+        PaymentData paymentData = random(PaymentData.class);
+
+        paymentDao.insert(List.of(paymentData));
+        paymentDao.update(List.of(paymentData));
+
+        PaymentData paymentDataWithPreviousEventId = new PaymentData(paymentData);
+        paymentDataWithPreviousEventId.setEventId(paymentData.getEventId() - 1);
+
+        paymentDao.update(List.of(paymentDataWithPreviousEventId));
         assertEquals(paymentData, paymentDao.get(paymentData.getInvoiceId(), paymentData.getPaymentId()));
     }
 

--- a/src/test/java/com/rbkmoney/magista/dao/RefundDaoTest.java
+++ b/src/test/java/com/rbkmoney/magista/dao/RefundDaoTest.java
@@ -1,6 +1,7 @@
 package com.rbkmoney.magista.dao;
 
 import com.rbkmoney.magista.dao.impl.RefundDaoImpl;
+import com.rbkmoney.magista.domain.tables.pojos.PaymentData;
 import com.rbkmoney.magista.domain.tables.pojos.RefundData;
 import com.rbkmoney.magista.exception.DaoException;
 import org.junit.Test;
@@ -25,5 +26,19 @@ public class RefundDaoTest extends AbstractDaoTest {
         refundDao.save(List.of(refund));
 
         assertEquals(refund, refundDao.get(refund.getInvoiceId(), refund.getPaymentId(), refund.getRefundId()));
+    }
+
+    @Test
+    public void updatePreviousEventTest() {
+        RefundData refundData = random(RefundData.class);
+
+        refundDao.save(List.of(refundData));
+        refundDao.save(List.of(refundData));
+
+        RefundData refundDataWithPreviousEventId = new RefundData(refundData);
+        refundDataWithPreviousEventId.setEventId(refundData.getEventId() - 1);
+
+        refundDao.save(List.of(refundDataWithPreviousEventId));
+        assertEquals(refundData, refundDao.get(refundData.getInvoiceId(), refundData.getPaymentId(), refundData.getRefundId()));
     }
 }


### PR DESCRIPTION
В случае, если по каким то причинам консьюмеры вернулись в прошлое, пропускаем эвенты, которые уже были обработаны.