### PR TITLE
JD:240: lightweight enum migration

### DIFF
--- a/src/main/java/com/rbkmoney/magista/dao/impl/AbstractDao.java
+++ b/src/main/java/com/rbkmoney/magista/dao/impl/AbstractDao.java
@@ -225,6 +225,12 @@ public abstract class AbstractDao extends NamedParameterJdbcDaoSupport {
                 condition = DSL.condition(operator, condition, buildCondition(field));
             }
         }
+        Optional<Condition> orCondition = conditionParameterSource.getOrConditions().stream().reduce(Condition::or);
+        if (orCondition.isPresent()) {
+            for (Condition parameterSourceCondition : conditionParameterSource.getOrConditions()) {
+                condition = DSL.condition(Operator.AND, condition, orCondition.get());
+            }
+        }
         return condition;
     }
 

--- a/src/main/java/com/rbkmoney/magista/dao/impl/SearchDaoImpl.java
+++ b/src/main/java/com/rbkmoney/magista/dao/impl/SearchDaoImpl.java
@@ -13,6 +13,7 @@ import com.rbkmoney.magista.query.impl.*;
 import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 
 import javax.sql.DataSource;
 
@@ -90,9 +91,6 @@ public class SearchDaoImpl extends AbstractDao implements SearchDao {
                         TypeUtil.toEnumField(parameters.getPaymentFlow(), PaymentFlow.class),
                         EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_TOOL, parameters.getPaymentMethod(), EQUALS)
-                .addValue(PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER,
-                        parameters.getPaymentBankCardTokenProvider(),
-                        EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_TERMINAL_PROVIDER, parameters.getPaymentTerminalProvider(), EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_EMAIL, parameters.getPaymentEmail(), EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_IP, parameters.getPaymentIp(), EQUALS)
@@ -111,8 +109,16 @@ public class SearchDaoImpl extends AbstractDao implements SearchDao {
                 .addValue(PAYMENT_DATA.PAYMENT_RRN, parameters.getPaymentRrn(), EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_APPROVAL_CODE, parameters.getPaymentApproveCode(), EQUALS)
                 .addValue(PAYMENT_DATA.EXTERNAL_ID, parameters.getExternalId(), EQUALS);
-
-        if (!paymentParameterSource.getConditionFields().isEmpty()) {
+        if (!ObjectUtils.isEmpty(parameters.getPaymentBankCardTokenProvider())) {
+            paymentParameterSource.addOrCondition(
+                    PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER
+                            .eq(parameters.getPaymentBankCardTokenProvider()),
+                    PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER_LEGACY.eq(
+                            toEnumField(parameters.getPaymentBankCardTokenProvider(),
+                                    com.rbkmoney.magista.domain.enums.BankCardTokenProvider.class)));
+        }
+        if (!paymentParameterSource.getConditionFields().isEmpty()
+                || !paymentParameterSource.getOrConditions().isEmpty()) {
             condition = condition.and(
                     DSL.exists(
                             getDslContext().select(DSL.field("1")).from(PAYMENT_DATA)
@@ -376,7 +382,7 @@ public class SearchDaoImpl extends AbstractDao implements SearchDao {
 
     private ConditionParameterSource preparePaymentsCondition(PaymentsFunction.PaymentsParameters parameters,
                                                               LocalDateTime whereTime) {
-        return new ConditionParameterSource()
+        ConditionParameterSource conditionParameterSource = new ConditionParameterSource()
                 .addValue(
                         PAYMENT_DATA.PARTY_ID,
                         Optional.ofNullable(parameters.getMerchantId())
@@ -397,9 +403,6 @@ public class SearchDaoImpl extends AbstractDao implements SearchDao {
                         toEnumField(parameters.getPaymentFlow(), PaymentFlow.class),
                         EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_TOOL, parameters.getPaymentMethod(), EQUALS)
-                .addValue(PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER,
-                        parameters.getPaymentBankCardTokenProvider(),
-                        EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_TERMINAL_PROVIDER, parameters.getPaymentTerminalProvider(), EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_EMAIL, parameters.getPaymentEmail(), EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_IP, parameters.getPaymentIp(), EQUALS)
@@ -421,6 +424,15 @@ public class SearchDaoImpl extends AbstractDao implements SearchDao {
                 .addValue(PAYMENT_DATA.PAYMENT_AMOUNT, parameters.getPaymentAmountFrom(), GREATER_OR_EQUAL)
                 .addValue(PAYMENT_DATA.PAYMENT_AMOUNT, parameters.getPaymentAmountTo(), LESS_OR_EQUAL)
                 .addValue(PAYMENT_DATA.EXTERNAL_ID, parameters.getExternalId(), EQUALS);
+        if (!ObjectUtils.isEmpty(parameters.getPaymentBankCardTokenProvider())) {
+            conditionParameterSource.addOrCondition(
+                    PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER
+                            .eq(parameters.getPaymentBankCardTokenProvider()),
+                    PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER_LEGACY.eq(
+                            toEnumField(parameters.getPaymentBankCardTokenProvider(),
+                                    com.rbkmoney.magista.domain.enums.BankCardTokenProvider.class)));
+        }
+        return conditionParameterSource;
     }
 
     /**
@@ -430,7 +442,7 @@ public class SearchDaoImpl extends AbstractDao implements SearchDao {
      */
     private ConditionParameterSource prepareEnrichedPaymentsCondition(PaymentsFunction.PaymentsParameters parameters,
                                                                       LocalDateTime whereTime) {
-        return new ConditionParameterSource()
+        ConditionParameterSource conditionParameterSource = new ConditionParameterSource()
                 .addValue(
                         PAYMENT_DATA.PARTY_ID,
                         Optional.ofNullable(parameters.getMerchantId())
@@ -449,9 +461,6 @@ public class SearchDaoImpl extends AbstractDao implements SearchDao {
                         toEnumField(parameters.getPaymentFlow(), PaymentFlow.class),
                         EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_TOOL, parameters.getPaymentMethod(), EQUALS)
-                .addValue(PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER,
-                        parameters.getPaymentBankCardTokenProvider(),
-                        EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_TERMINAL_PROVIDER, parameters.getPaymentTerminalProvider(), EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_EMAIL, parameters.getPaymentEmail(), EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_IP, parameters.getPaymentIp(), EQUALS)
@@ -469,6 +478,16 @@ public class SearchDaoImpl extends AbstractDao implements SearchDao {
                 .addValue(PAYMENT_DATA.PAYMENT_RRN, parameters.getPaymentRrn(), EQUALS)
                 .addValue(PAYMENT_DATA.PAYMENT_APPROVAL_CODE, parameters.getPaymentApproveCode(), EQUALS)
                 .addValue(PAYMENT_DATA.EXTERNAL_ID, parameters.getExternalId(), EQUALS);
+        if (!ObjectUtils.isEmpty(parameters.getPaymentBankCardTokenProvider())) {
+            conditionParameterSource.addOrCondition(
+                    PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER
+                            .eq(parameters.getPaymentBankCardTokenProvider()),
+                    PAYMENT_DATA.PAYMENT_BANK_CARD_TOKEN_PROVIDER_LEGACY.eq(
+                            toEnumField(parameters.getPaymentBankCardTokenProvider(),
+                                    com.rbkmoney.magista.domain.enums.BankCardTokenProvider.class)));
+        }
+
+        return conditionParameterSource;
     }
 
     /**

--- a/src/main/java/com/rbkmoney/magista/dao/impl/field/ConditionParameterSource.java
+++ b/src/main/java/com/rbkmoney/magista/dao/impl/field/ConditionParameterSource.java
@@ -1,9 +1,11 @@
 package com.rbkmoney.magista.dao.impl.field;
 
 import org.jooq.Comparator;
+import org.jooq.Condition;
 import org.jooq.Field;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -14,8 +16,11 @@ public class ConditionParameterSource {
 
     private List<ConditionField> conditionFields;
 
+    private List<Condition> orConditions;
+
     public ConditionParameterSource() {
         this.conditionFields = new ArrayList<>();
+        this.orConditions = new ArrayList<>();
     }
 
     public <T> ConditionParameterSource addValue(Field<T> field, T value, Comparator comparator) {
@@ -34,8 +39,17 @@ public class ConditionParameterSource {
         return this;
     }
 
+    public ConditionParameterSource addOrCondition(Condition... condition) {
+        orConditions.addAll(Arrays.asList(condition));
+        return this;
+    }
+
     public List<ConditionField> getConditionFields() {
         return conditionFields;
+    }
+
+    public List<Condition> getOrConditions() {
+        return orConditions;
     }
 
     @Override

--- a/src/main/resources/db/migration/V22__enum_to_string_mobile_operator_bank_token.sql
+++ b/src/main/resources/db/migration/V22__enum_to_string_mobile_operator_bank_token.sql
@@ -1,7 +1,9 @@
 ALTER TABLE mst.payment_data
-    ALTER COLUMN payment_bank_card_token_provider TYPE VARCHAR USING payment_bank_card_token_provider::VARCHAR;
+    RENAME COLUMN payment_bank_card_token_provider TO payment_bank_card_token_provider_legacy;
 ALTER TABLE mst.payment_data
-    ALTER COLUMN payment_mobile_operator TYPE VARCHAR USING payment_mobile_operator::VARCHAR;
+    RENAME COLUMN payment_mobile_operator TO payment_mobile_operator_legacy;
 
-DROP TYPE mst.mobile_operator_type;
-DROP TYPE mst.bank_card_token_provider;
+ALTER TABLE mst.payment_data
+    ADD COLUMN payment_bank_card_token_provider CHARACTER VARYING;
+ALTER TABLE mst.payment_data
+    ADD COLUMN payment_mobile_operator CHARACTER VARYING;


### PR DESCRIPTION
Сделал миграцию базы полегче, чтоб не повисала транзакция.
Для этого добавил новую колонку и depricate'нул старую, а также учел это при поиске инвойсов, платежей и т.д.